### PR TITLE
fix(#36): always load the dom shim if the nuxt-ssr-lit module is used

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -27,6 +27,7 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
     const { resolve } = createResolver(import.meta.url);
     const resolveRuntimeModule = (path: string) => resolveModule(path, { paths: resolve("./runtime") });
 
+    addPlugin(resolveRuntimeModule("./plugins/shim.server"));
     addPlugin(resolveRuntimeModule("./plugins/shim.client"));
     addPlugin(resolveRuntimeModule("./plugins/hydrateSupport.client"));
 

--- a/src/runtime/plugins/shim.server.ts
+++ b/src/runtime/plugins/shim.server.ts
@@ -1,0 +1,4 @@
+import "@lit-labs/ssr/lib/install-global-dom-shim.js";
+import { defineNuxtPlugin } from "#imports";
+
+export default defineNuxtPlugin(() => {});


### PR DESCRIPTION
Adding the DOM shim _also_ as a server plugin ensures that when the `nuxt-ssr-lit` module is used, the shim is applied. Otherwise, the shim gets applied ONLY when one of the components is being used in one of the Nuxt pages. This breaks in situations where a component may not be used in any of the pages, but the component definition is still being imported. Then `customElement.get` won't be available.

