### PR TITLE
feat: process vue files outside the src dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ That's it! Now all the Lit elements prefixed with `acme-` will be Server-Side Re
 
 All the Lit elements in the Nuxt project that uses the prefix(es) provided in the module option are wrapped with a Vue component called [LitWrapper](./src/runtime/components/LitWrapper.vue).
 
-This auto-wrapping is done via a Vite Plugin called [AutoLitWrapper](./src/runtime/plugins/autoLitWrapper.ts) and therefore happens during build time. And the plugin, by default, only transforms code in the directories where Vue components are present. This keeps the Vite plugin fast by preventing unnecessary work.
+This auto-wrapping is done via a Vite Plugin called [AutoLitWrapper](./src/runtime/plugins/autoLitWrapper.ts) and therefore happens during build time. By default, the plugin only operates on Vue files, which helps to optimize performance by avoiding unnecessary processing.
 
 So, if there is a Lit element used in one of the components. E.g. `<acme-button>Hello world</acme-button>`, the code that is actually generated and used by Nuxt/Vue will be `<LitWrapper><acme-button>Hello world</acme-button></LitWrapper>`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@lit-labs/ssr": "^3.0.0",
         "@nuxt/kit": "^3.0.0",
         "@webcomponents/template-shadowroot": "^0.1.0",
-        "magic-string": "^0.26.7"
+        "magic-string": "^0.26.7",
+        "ufo": "^1.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.2.0",
@@ -1465,11 +1466,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/@nuxt/kit/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
-    },
     "node_modules/@nuxt/kit/node_modules/unimport": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-1.2.0.tgz",
@@ -1685,11 +1681,6 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
-    },
-    "node_modules/@nuxt/schema/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
     },
     "node_modules/@nuxt/schema/node_modules/unimport": {
       "version": "1.2.0",
@@ -1976,6 +1967,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@nuxt/test-utils-edge/node_modules/ufo": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+      "dev": true
+    },
     "node_modules/@nuxt/ui-templates": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@nuxt/ui-templates/-/ui-templates-1.1.0.tgz",
@@ -2184,12 +2181,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/@nuxt/vite-builder/node_modules/unplugin": {
       "version": "1.0.1",
@@ -6317,12 +6308,6 @@
         "pathe": "^1.0.0"
       }
     },
-    "node_modules/externality/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7073,12 +7058,6 @@
         "radix3": "^1.0.0",
         "ufo": "^1.0.1"
       }
-    },
-    "node_modules/h3/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -8109,12 +8088,6 @@
         "ufo": "^1.0.0"
       }
     },
-    "node_modules/listhen/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/lit": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.0.tgz",
@@ -9055,6 +9028,12 @@
         "ufo": "^0.8.5"
       }
     },
+    "node_modules/mlly/node_modules/ufo": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+      "dev": true
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -9360,12 +9339,6 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
-    },
-    "node_modules/nitropack/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/nitropack/node_modules/unimport": {
       "version": "1.2.0",
@@ -9744,12 +9717,6 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
-    "node_modules/nuxt/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/nuxt/node_modules/unimport": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-1.2.0.tgz",
@@ -9890,12 +9857,6 @@
       "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
       "dev": true
     },
-    "node_modules/ofetch/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/ohash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.0.0.tgz",
@@ -9913,6 +9874,12 @@
         "ufo": "^0.8.6",
         "undici": "^5.12.0"
       }
+    },
+    "node_modules/ohmyfetch/node_modules/ufo": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+      "dev": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -12470,10 +12437,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
-      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
     },
     "node_modules/ultrahtml": {
       "version": "1.2.0",
@@ -13289,12 +13255,6 @@
         "ws": "^8.11.0"
       }
     },
-    "node_modules/unstorage/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/untyped": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/untyped/-/untyped-0.5.0.tgz",
@@ -13484,12 +13444,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/vite-node/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
-    },
     "node_modules/vitest": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.24.1.tgz",
@@ -13626,12 +13580,6 @@
       "dependencies": {
         "ufo": "^1.0.0"
       }
-    },
-    "node_modules/vue-bundle-renderer/node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/vue-devtools-stub": {
       "version": "0.1.0",
@@ -15134,11 +15082,6 @@
             "acorn": "^8.8.1"
           }
         },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
-        },
         "unimport": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/unimport/-/unimport-1.2.0.tgz",
@@ -15328,11 +15271,6 @@
           "requires": {
             "acorn": "^8.8.1"
           }
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
         },
         "unimport": {
           "version": "1.2.0",
@@ -15554,6 +15492,12 @@
           "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
           "dev": true
+        },
+        "ufo": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+          "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+          "dev": true
         }
       }
     },
@@ -15722,12 +15666,6 @@
           "dev": true,
           "optional": true,
           "peer": true
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         },
         "unplugin": {
           "version": "1.0.1",
@@ -18645,12 +18583,6 @@
             "mlly": "^1.0.0",
             "pathe": "^1.0.0"
           }
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         }
       }
     },
@@ -19215,14 +19147,6 @@
         "destr": "^1.2.2",
         "radix3": "^1.0.0",
         "ufo": "^1.0.1"
-      },
-      "dependencies": {
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
       }
     },
     "hard-rejection": {
@@ -19949,14 +19873,6 @@
         "ip-regex": "^5.0.0",
         "node-forge": "^1.3.1",
         "ufo": "^1.0.0"
-      },
-      "dependencies": {
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
       }
     },
     "lit": {
@@ -20594,6 +20510,14 @@
         "pathe": "^0.3.8",
         "pkg-types": "^0.3.5",
         "ufo": "^0.8.5"
+      },
+      "dependencies": {
+        "ufo": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+          "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+          "dev": true
+        }
       }
     },
     "mri": {
@@ -20834,12 +20758,6 @@
           "requires": {
             "acorn": "^8.8.1"
           }
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         },
         "unimport": {
           "version": "1.2.0",
@@ -21136,12 +21054,6 @@
             "acorn": "^8.8.1"
           }
         },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        },
         "unimport": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/unimport/-/unimport-1.2.0.tgz",
@@ -21261,12 +21173,6 @@
           "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
           "integrity": "sha512-VzW+TAk2wE4X9maiKMlT+GsPU4OMmR1U9CrHSmd3DFLn2IcZ9VJ6M6BBugGfYUnPCLSYxXdZy17M0BEJyhUTwg==",
           "dev": true
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         }
       }
     },
@@ -21286,6 +21192,14 @@
         "node-fetch-native": "^0.1.8",
         "ufo": "^0.8.6",
         "undici": "^5.12.0"
+      },
+      "dependencies": {
+        "ufo": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+          "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
+          "dev": true
+        }
       }
     },
     "on-finished": {
@@ -23098,10 +23012,9 @@
       "dev": true
     },
     "ufo": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
-      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA=="
     },
     "ultrahtml": {
       "version": "1.2.0",
@@ -23657,14 +23570,6 @@
         "ofetch": "^1.0.0",
         "ufo": "^1.0.0",
         "ws": "^8.11.0"
-      },
-      "dependencies": {
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
       }
     },
     "untyped": {
@@ -23795,12 +23700,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
         }
       }
     },
@@ -23897,14 +23796,6 @@
       "dev": true,
       "requires": {
         "ufo": "^1.0.0"
-      },
-      "dependencies": {
-        "ufo": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-          "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-          "dev": true
-        }
       }
     },
     "vue-devtools-stub": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@lit-labs/ssr": "^3.0.0",
     "@nuxt/kit": "^3.0.0",
     "@webcomponents/template-shadowroot": "^0.1.0",
-    "magic-string": "^0.26.7"
+    "magic-string": "^0.26.7",
+    "ufo": "^1.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.2.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,6 @@ import autoLitWrapper from "./runtime/plugins/autoLitWrapper";
 
 export interface NuxtSsrLitOptions {
   litElementPrefix: string | string[];
-  templateSources?: string[];
 }
 
 export default defineNuxtModule<NuxtSsrLitOptions>({
@@ -14,8 +13,7 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
     configKey: "ssrLit"
   },
   defaults: {
-    litElementPrefix: "",
-    templateSources: ["pages", "components", "layouts", "app.vue"]
+    litElementPrefix: ""
   },
   async setup(options, nuxt) {
     nuxt.options.nitro.moduleSideEffects = nuxt.options.nitro.moduleSideEffects || [];
@@ -49,13 +47,9 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
         ? options.litElementPrefix.some((p) => tag.startsWith(p))
         : tag.startsWith(options.litElementPrefix)) || isCustomElement(tag);
 
-    const srcDir = nuxt.options.srcDir;
-
     addVitePlugin(
       autoLitWrapper({
         litElementPrefix: options.litElementPrefix,
-        templateSources: options.templateSources,
-        srcDir,
         sourcemap: nuxt.options.sourcemap
       })
     );

--- a/tests/module/autoLitWrapper.spec.ts
+++ b/tests/module/autoLitWrapper.spec.ts
@@ -23,17 +23,15 @@ describe("Lit wrapper plugin", () => {
   });
   test("Returns the code unmodified if there are no matching elements", () => {
     const plugin = autoLitWrapper({
-      litElementPrefix: "my-",
-      srcDir: "src"
+      litElementPrefix: "my-"
     });
-    const t = plugin.transform(sampleMyElement, "src/components/my-element");
+    const t = plugin.transform(sampleMyElement, "src/components/my-element.vue");
     expect(t.code).toEqual(sampleMyElement);
   });
 
   test("Wraps the template code if there are matching elements", () => {
     const plugin = autoLitWrapper({
-      litElementPrefix: "my-",
-      srcDir: "src"
+      litElementPrefix: "my-"
     });
     const t = plugin.transform(samplePage, "src/pages/index.vue");
     expect(t.code).toContain("<LitWrapper><my-element>I am a SSR-ed Lit element</my-element></LitWrapper>");
@@ -41,8 +39,7 @@ describe("Lit wrapper plugin", () => {
 
   test("Wraps the code when multiple different components are present", () => {
     const plugin = autoLitWrapper({
-      litElementPrefix: "my-",
-      srcDir: "src"
+      litElementPrefix: "my-"
     });
     const t = plugin.transform(sampleNestedComponentPage, "src/pages/nested-lit-element-in-slot.vue");
     const expectedCode = `<LitWrapper><my-element>
@@ -57,4 +54,12 @@ describe("Lit wrapper plugin", () => {
   });
 
   test("Wraps only the outer element if lit-elements are nested", () => {});
+
+  test("Wraps the custom element in a Vue file that is outside the src directory", () => {
+    const plugin = autoLitWrapper({
+      litElementPrefix: "my-"
+    });
+    const t = plugin.transform(samplePage, "packages/foo-bar/components/page.vue");
+    expect(t.code).toContain("<LitWrapper><my-element>I am a SSR-ed Lit element</my-element></LitWrapper>");
+  });
 });


### PR DESCRIPTION
This allows us to auto-wrap components that could be imported from node_modules or other directories using Nuxt's auto-import.

Additionally, limiting the usage to only Vue files helps to maintain the plugin's performance.