### PR TITLE
Move v-if, v-else-if, v-else to the wrapper if found in the custom elements

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -27,6 +27,9 @@
           <li>
             <NuxtLink to="/with-v-for"> With v-for </NuxtLink>
           </li>
+          <li>
+            <NuxtLink to="/with-v-if"> With v-if </NuxtLink>
+          </li>
         </ul>
       </nav>
     </header>

--- a/playground/pages/with-v-if.vue
+++ b/playground/pages/with-v-if.vue
@@ -1,0 +1,9 @@
+<template>
+  <article>
+    <my-accordion>
+      <my-accordion-item v-if="true" title="I should be shown"> foo </my-accordion-item>
+      <my-accordion-item v-else-if="false" title="I should not be shown"> bar </my-accordion-item>
+      <my-accordion-item v-else title="I should also not be shown"> baz </my-accordion-item>
+    </my-accordion>
+  </article>
+</template>

--- a/tests/module/autoLitWrapper.spec.ts
+++ b/tests/module/autoLitWrapper.spec.ts
@@ -13,10 +13,12 @@ describe("Lit wrapper plugin", () => {
   let samplePage = "";
   let sampleNestedComponentPage = "";
   let sampleVForPage = "";
+  let sampleVIfPage = "";
 
   beforeAll(async () => {
     samplePage = await loadFile("pages/index.vue");
     sampleVForPage = await loadFile("pages/with-v-for.vue");
+    sampleVIfPage = await loadFile("pages/with-v-if.vue");
     sampleNestedComponentPage = await loadFile("pages/nested-lit-element-in-slot.vue");
   });
 
@@ -60,5 +62,19 @@ describe("Lit wrapper plugin", () => {
     expect(t.code).toContain('<LitWrapper v-for="(item, index) in items" :key="item.title"><my-accordion-item');
     expect(t.code.match(/v-for/g)?.length).toBe(1);
     expect(t.code.match(/:key/g)?.length).toBe(1);
+  });
+
+  test("Wraps the custom element with v-if and v-else and moves them to the corresponding wrapper", async () => {
+    const plugin = autoLitWrapper({
+      litElementPrefix: ["my-"]
+    });
+    const t = await plugin.transform(sampleVIfPage, "src/pages/with-v-if.vue");
+
+    expect(t.code).toContain('<LitWrapper v-if="true"><my-accordion-item');
+    expect(t.code).toContain('<LitWrapper v-else-if="false"><my-accordion-item');
+    expect(t.code).toContain('<LitWrapper v-else=""><my-accordion-item');
+
+    expect(t.code.match(/v-if/g)?.length).toBe(1);
+    expect(t.code.match(/v-else/g)?.length).toBe(2);
   });
 });


### PR DESCRIPTION
Without special transfer for the v-if related attributes, 

```
<acme-button v-if="test">Test</acme-button> 
<acme-button v-else>Rest</acme-button> 
```

gets transformed to

```
<LitWrapper><acme-button v-if="test">Test</acme-button></LitWrapper>
<LitWrapper><acme-button v-else>Rest</acme-button> </LitWrapper>
```

Which is invalid.

This PR makes sure that the transformation results in the following:

```
<LitWrapper v-if="test"><acme-button>Test</acme-button></LitWrapper>
<LitWrapper v-else><acme-button>Rest</acme-button> </LitWrapper>
```