### PR TITLE
fix issue with custom element nested inside render of another custom element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-ssr-lit",
-  "version": "1.4.1",
+  "version": "1.4.2-beta.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/src/runtime/components/LitWrapperServer.ts
+++ b/src/runtime/components/LitWrapperServer.ts
@@ -74,7 +74,14 @@ export default defineComponent({
     },
 
     getShadowContents() {
-      return this.iterableToString(this.renderer.renderShadow({}));
+      return this.iterableToString(
+        this.renderer.renderShadow({
+          elementRenderers: [LitElementRenderer],
+          customElementInstanceStack: [],
+          customElementHostStack: [],
+          deferHydration: true
+        })
+      );
     },
 
     iterableToString(iterable: Iterable<string>) {
@@ -117,8 +124,7 @@ export default defineComponent({
 
     return h(this.litElementTagName, {
       innerHTML: this.litSsrHtml,
-      ...props,
-      "defer-hydration": true
+      ...props
     });
   }
 });

--- a/tests/playground/basic.spec.ts
+++ b/tests/playground/basic.spec.ts
@@ -11,29 +11,21 @@ describe("ssr", async () => {
 
   it("renders the index page with a single simple element", async () => {
     const html = await $fetch("/");
-    expect(html).toContain(
-      '<my-element defer-hydration="true"><template shadowrootmode="open" shadowroot="open"><style>'
-    );
+    expect(html).toContain('<my-element><template shadowrootmode="open" shadowroot="open"><style>');
     expect(html).toContain("<!--/lit-part--></template>I am a SSR-ed Lit element</my-element>");
   });
 
   it("renders multiple different element tags when supplied", async () => {
     const html = await $fetch("/multiple-different-element-tags");
-    expect(html).toContain(
-      '<my-element defer-hydration="true"><template shadowrootmode="open" shadowroot="open"><style>'
-    );
+    expect(html).toContain('<my-element><template shadowrootmode="open" shadowroot="open"><style>');
     expect(html).toContain("<!--/lit-part--></template>I am a SSR-ed Lit element</my-element>");
-    expect(html).toContain(
-      '<simple-button defer-hydration="true"><template shadowrootmode="open" shadowroot="open"><style>'
-    );
+    expect(html).toContain('<simple-button><template shadowrootmode="open" shadowroot="open"><style>');
     expect(html).toContain("<!--/lit-part--></template>And so am I</simple-button>");
   });
 
   it("renders nested lit components", async () => {
     const html = await $fetch("/nested-lit-element-in-slot");
-    expect(html).toContain(
-      '<my-element defer-hydration="true"><template shadowrootmode="open" shadowroot="open"><style>'
-    );
+    expect(html).toContain('<my-element><template shadowrootmode="open" shadowroot="open"><style>');
     expect(html).toContain(
       '<!--/lit-part--></template><div slot="prepend">I am a Lit element within another Lit element</div></my-element>'
     );
@@ -41,9 +33,7 @@ describe("ssr", async () => {
 
   it("renders component attributes", async () => {
     const html = await $fetch("/simple-element");
-    expect(html).toContain(
-      '<simple-button disabled defer-hydration="true"><template shadowrootmode="open" shadowroot="open"><style>'
-    );
+    expect(html).toContain('<simple-button disabled><template shadowrootmode="open" shadowroot="open"><style>');
   });
 
   it("renders boolean property correctly on server", async () => {


### PR DESCRIPTION
`v3.0.1` of `@lit-labs/ssr` does not add default renderInfo when calling `renderShadow` on the `LitElementRenderer`. This causes an issue when a custom element is nested inside another custom element.

Seems like a bug in `@lit-labs/ssr`, but this is a workaround for now.