### PR TITLE
chore: add example page for provide/inject

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -30,6 +30,9 @@
           <li>
             <NuxtLink to="/with-v-if"> With v-if </NuxtLink>
           </li>
+          <li>
+            <NuxtLink to="/with-provide-inject"> With provide/inject </NuxtLink>
+          </li>
         </ul>
       </nav>
     </header>

--- a/playground/components/ComponentWithInject.vue
+++ b/playground/components/ComponentWithInject.vue
@@ -1,0 +1,11 @@
+<template>
+  <h1>
+    {{ injectedVariable }}
+  </h1>
+</template>
+
+<script setup>
+import { inject } from "vue";
+
+const injectedVariable = inject("injectedVariable");
+</script>

--- a/playground/pages/with-provide-inject.vue
+++ b/playground/pages/with-provide-inject.vue
@@ -1,0 +1,11 @@
+<template>
+  <simple-button>
+    <ComponentWithInject />
+  </simple-button>
+</template>
+
+<script setup>
+import { provide } from "vue";
+
+provide("injectedVariable", "I am injected");
+</script>


### PR DESCRIPTION
A simple example page that can be used to test that provide/inject works with this module.

As of now, provide/inject does not work with the module because of the way the slots of the Lit elements are being rendered during SSR. 