### PR TITLE
feat: change the way we render the component on server

### DIFF
--- a/playground/components/ComponentWithInject.vue
+++ b/playground/components/ComponentWithInject.vue
@@ -1,5 +1,5 @@
 <template>
-  <h1>
+  <h1 id="injectedVariable">
     {{ injectedVariable }}
   </h1>
 </template>

--- a/src/runtime/utils/litElementRenderer.ts
+++ b/src/runtime/utils/litElementRenderer.ts
@@ -1,0 +1,59 @@
+import { LitElementRenderer } from "@lit-labs/ssr/lib/lit-element-renderer.js";
+import { getCustomElementConstructor, isCustomElementTag } from "./customElements";
+
+export function createLitElementRenderer(tagName: string, props: Record<string, unknown>): LitElementRenderer | null {
+  if (!isCustomElementTag(tagName)) {
+    return null;
+  }
+
+  const renderer = new LitElementRenderer(tagName);
+  return attachPropsToRenderer(renderer, props);
+}
+
+export function getShadowContents(renderer: LitElementRenderer): string {
+  return iterableToString(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    renderer.renderShadow({
+      elementRenderers: [LitElementRenderer],
+      customElementInstanceStack: [],
+      customElementHostStack: []
+    }) as Iterable<string>
+  );
+}
+
+function attachPropsToRenderer(renderer: LitElementRenderer, props: Record<string, unknown>): LitElementRenderer {
+  const customElementConstructor = getCustomElementConstructor(renderer.tagName);
+
+  if (props) {
+    for (const [key, value] of Object.entries(props)) {
+      // check if this is a reactive property
+      if (
+        customElementConstructor !== null &&
+        typeof customElementConstructor !== "string" &&
+        key in customElementConstructor.prototype
+      ) {
+        const isBooleanProp = customElementConstructor.elementProperties.get(key)?.type === Boolean;
+
+        if (isBooleanProp && value === "") {
+          // handle key only boolean props e.g. <my-element disabled></my-element>
+          renderer.setProperty(key, true);
+        } else {
+          renderer.setProperty(key, value);
+        }
+      } else {
+        renderer.setAttribute(key, value as string);
+      }
+    }
+  }
+
+  return renderer;
+}
+
+function iterableToString(iterable: Iterable<string>) {
+  let s = "";
+  for (const i of iterable) {
+    s += i;
+  }
+  return s;
+}

--- a/src/runtime/utils/ssr.ts
+++ b/src/runtime/utils/ssr.ts
@@ -1,0 +1,33 @@
+import { isString, isPromise, isArray } from "@vue/shared";
+
+// eslint-disable-next-line no-use-before-define
+export type SSRBuffer = SSRBufferItem[] & { hasAsync?: boolean };
+export type SSRBufferItem = string | SSRBuffer | Promise<SSRBuffer>;
+
+/**
+ * create buffer retrieved from @vue/server-renderer
+ *
+ * @see https://github.com/vuejs/core/blob/9617dd4b2abc07a5dc40de6e5b759e851b4d0da1/packages/server-renderer/src/render.ts#L57
+ * @private
+ */
+export function createSSRVNodesBuffer() {
+  let appendable = false;
+  const buffer: SSRBuffer = [];
+  return {
+    getBuffer(): SSRBuffer {
+      return buffer;
+    },
+    push(item: SSRBufferItem) {
+      const isStringItem = isString(item);
+      if (appendable && isStringItem) {
+        buffer[buffer.length - 1] += item as string;
+      } else {
+        buffer.push(item);
+      }
+      appendable = isStringItem;
+      if (isPromise(item) || (isArray(item) && item.hasAsync)) {
+        buffer.hasAsync = true;
+      }
+    }
+  };
+}

--- a/tests/playground/basic.spec.ts
+++ b/tests/playground/basic.spec.ts
@@ -53,4 +53,11 @@ describe("ssr", async () => {
     expect($(".accordion-item__content").eq(0).attr()?.hidden).toBeUndefined();
     expect($(".accordion-item__content").eq(1).attr()?.hidden).toBeDefined();
   });
+
+  it("renders provide/inject correctly on server", async () => {
+    const html = await $fetch("/with-provide-inject");
+
+    const $ = cheerio.load(html);
+    expect($("#injectedVariable").text()).toBe("I am injected");
+  });
 });


### PR DESCRIPTION
Instead of using `render` hook, `serverPrefetch`hook and `renderToString` (for Lit element slots), we now leverage SSR primitives like `ssrRender` hook, and `ssrRenderVNode` from `@vue/server-renderer`

Fixes #92 while keeping the same API.