### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ _Note: This module is for Nuxt3._ The [work on Nuxt2 support](https://github.com
 Install `nuxt-ssr-lit`.
 
 ```shell
-npm install nuxt-ssr-lit
-# yarn add nuxt-ssr-lit
+npx nuxi@latest module add ssr-lit
+# npx nuxi@latest module add ssr-lit
 ```
 
 Add following code to modules section of nuxt.config.js.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Install `nuxt-ssr-lit`.
 
 ```shell
 npx nuxi@latest module add ssr-lit
-# npx nuxi@latest module add ssr-lit
 ```
 
 Add following code to modules section of nuxt.config.js.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
