### PR TITLE
fix: only alter the template for the lit components, nothing else

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@lit-labs/ssr": "^3.2.1",
         "@nuxt/kit": "^3.11.2",
         "@webcomponents/template-shadowroot": "^0.2.1",
+        "magic-string": "^0.30.10",
         "ufo": "^1.3.2",
         "ultrahtml": "^1.5.2"
       },
@@ -11574,14 +11575,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
-      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/magic-string-ast": {
@@ -26735,9 +26733,9 @@
       }
     },
     "magic-string": {
-      "version": "0.30.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
-      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@lit-labs/ssr": "^3.2.1",
     "@nuxt/kit": "^3.11.2",
     "@webcomponents/template-shadowroot": "^0.2.1",
+    "magic-string": "^0.30.10",
     "ufo": "^1.3.2",
     "ultrahtml": "^1.5.2"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -46,6 +46,11 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
         ? options.litElementPrefix.some((p) => tag.startsWith(p))
         : tag.startsWith(options.litElementPrefix)) || isCustomElement(tag);
 
-    addVitePlugin(autoLitWrapper({ litElementPrefix: options.litElementPrefix }));
+    addVitePlugin(
+      autoLitWrapper({
+        litElementPrefix: options.litElementPrefix,
+        sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
+      })
+    );
   }
 });


### PR DESCRIPTION
[Ultrahtml](https://github.com/natemoo-re/ultrahtml) has some issues with parsing HTML which is specific DSL of Vue. E.g. a scoped slot template like

```html
<template #someslot="{ someProp }">
  <div>{{ someProp }}</div>
</template>
```

is rendered incorrectly by the Ultrahtml renderer.

```html
<template ="}"" someProp="">
<div>{{ someProp }}</div>
</template>
```

Before this PR, we rendered the entire generated AST using Ultrahtml's renderer.

This caused such scoped slots templates to be incorrect after the `autoLitWrapper` plugin was applied.

With this PR, we now surgically alter only the Lit elements configured to be auto-wrapped. Nothing else. And we do this using [magic-string](https://www.npmjs.com/package/magic-string).

This leaves the rest of the template as is. And we do not run into the shortcomings of Ultrahtml.