### PR TITLE
FIX: pin lit labs ssr to version 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.30",
       "license": "MIT",
       "dependencies": {
-        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr": "3.2.2",
         "@nuxt/kit": "^3.16.2",
         "@vue/compiler-core": "^3.5.13",
         "@vue/compiler-sfc": "^3.5.13",
@@ -3759,20 +3759,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/@nuxt/vite-builder/node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@nuxt/vite-builder/node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -4853,6 +4839,7 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -18777,17 +18764,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
-    "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -21650,14 +21626,6 @@
           "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
           "dev": true
         },
-        "meow": {
-          "version": "13.2.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-          "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "npm-run-path": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -22248,7 +22216,8 @@
       "dependencies": {
         "napi-wasm": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -31681,14 +31650,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
-    },
-    "webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "webpack-virtual-modules": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@lit-labs/ssr": "^3.2.2",
+    "@lit-labs/ssr": "3.2.2",
     "@nuxt/kit": "^3.16.2",
     "@vue/compiler-core": "^3.5.13",
     "@vue/compiler-sfc": "^3.5.13",


### PR DESCRIPTION
**Problem**
When starting a fresh Nuxt 3 project and installing nuxt-ssr-lit, server-side rendering fails due to a breaking change introduced in [lit/lit#4755](https://github.com/lit/lit/pull/4755) `@lit-labs/ssr`. The error looks like this:

```
Cannot read properties of undefined (reading 'has')                                                                                                            
    at LitElementRenderer.connectedCallback (@lit-labs/ssr/lib/lit-element-renderer.js:79:37)
    at ssrRender (node_modules/nuxt-ssr-lit/dist/runtime/components/LitWrapperServer.vue:17:16)
    at renderComponentSubTree (.../node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:715:9)
    at renderComponentVNode (.../node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:664:12)
    at renderVNode (.../node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:779:14)
```

**Proposed solution**
Pin `@lit-labs/ssr` to version 3.2.2 until a proper upstream fix is released. This prevents the runtime error and unblocks developers starting new projects with Nuxt 3 + nuxt-ssr-lit.