### PR TITLE
feat(plugin): suppress lit warnings mode in dev mode

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,7 +2,17 @@ import { defineNuxtConfig } from "nuxt/config";
 import NuxtSsrLit from "..";
 
 export default defineNuxtConfig({
-  modules: [[NuxtSsrLit, { litElementPrefix: ["my-", "simple-"] }]],
+  modules: [
+    [
+      NuxtSsrLit,
+      {
+        litElementPrefix: ["my-", "simple-"],
+        suppressedWarnings: [
+          "Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information."
+        ]
+      }
+    ]
+  ],
   sourcemap: process.env.NODE_ENV === "test" ? false : { client: true, server: true },
   compatibilityDate: "2024-11-05",
   hooks: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,9 +1,11 @@
 import { defineNuxtModule, addPlugin, createResolver, addVitePlugin, addComponent } from "@nuxt/kit";
 import { name, version } from "../package.json";
+import supressLitWarnings from "./runtime/plugins/supressLitWarnings";
 import autoLitWrapper from "./runtime/plugins/autoLitWrapper";
 
 export interface NuxtSsrLitOptions {
   litElementPrefix: string | string[];
+  suppressedWarnings?: string[];
 }
 
 export default defineNuxtModule<NuxtSsrLitOptions>({
@@ -13,7 +15,8 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
     configKey: "ssrLit"
   },
   defaults: {
-    litElementPrefix: []
+    litElementPrefix: [],
+    suppressedWarnings: []
   },
   async setup(options, nuxt) {
     nuxt.options.nitro.moduleSideEffects = nuxt.options.nitro.moduleSideEffects || [];
@@ -45,6 +48,10 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
       (Array.isArray(options.litElementPrefix)
         ? options.litElementPrefix.some((p) => tag.startsWith(p))
         : tag.startsWith(options.litElementPrefix)) || isCustomElement(tag);
+
+    if (nuxt.options.dev || nuxt.options.test) {
+      addVitePlugin(supressLitWarnings(options.suppressedWarnings));
+    }
 
     addVitePlugin(
       autoLitWrapper({

--- a/src/runtime/plugins/supressLitWarnings.ts
+++ b/src/runtime/plugins/supressLitWarnings.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from "vite";
+
+export default function supressLitWarnings(warnings: string[] = []): Plugin {
+  return {
+    name: "suppress-lit-warnings",
+    enforce: "pre",
+    transform(code, id) {
+      if (["entry.mjs", "client.mjs"].some((ending) => id.endsWith(ending))) {
+        const patch = `globalThis.litIssuedWarnings = new Set(${JSON.stringify(warnings)});`;
+        return `${patch}\n${code}`;
+      }
+      return null;
+    }
+  };
+}


### PR DESCRIPTION
Lit issues warnings in dev mode that Lit is not running in production. For many people, this warning is annoying because this clutters the console output in dev mode and when running tests. See https://github.com/lit/lit/issues/4877

This PR adds a module option to provide an array of warnings you want to suppress in dev or test mode. This helps clean up the console by removing unnecessary warnings.