### PR TITLE
fix: keep @vue/server-renderer external to avoid SSR crash under pnpm

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,18 @@ export default defineNuxtModule<NuxtSsrLitOptions>({
     nuxt.options.nitro.moduleSideEffects = nuxt.options.nitro.moduleSideEffects || [];
     nuxt.options.nitro.moduleSideEffects.push("@lit-labs/ssr/lib/render-lit-html.js");
 
+    // Under strict node_modules layouts (e.g. pnpm), @vue/server-renderer gets bundled as CJS,
+    // emitting `import require$$0 from "vue"` and crashing SSR with "vue ... no default export". #176
+    nuxt.options.vite.ssr = nuxt.options.vite.ssr || {};
+    const ssrExternal = nuxt.options.vite.ssr.external;
+    if (Array.isArray(ssrExternal)) {
+      if (!ssrExternal.includes("@vue/server-renderer")) {
+        ssrExternal.push("@vue/server-renderer");
+      }
+    } else if (ssrExternal === undefined) {
+      nuxt.options.vite.ssr.external = ["@vue/server-renderer"];
+    }
+
     const { resolve } = createResolver(import.meta.url);
 
     addPlugin(resolve("./runtime/plugins/antiFouc.server"));


### PR DESCRIPTION
## Summary

Under strict node_modules layouts (e.g. pnpm), production builds bundle `@vue/server-renderer` as CJS, emitting `import require$$0 from "vue"`.
Since `vue` has no default export, SSR crashes at runtime with:

> The requested module 'vue' does not provide an export named 'default'

Keeping `@vue/server-renderer` external lets Node resolve the ESM build instead.

## Changes

- `src/module.ts` — add `@vue/server-renderer` to `vite.ssr.external` (preserves any existing external config)

## Verification

- Reproduced the 500 in a pnpm-based Nuxt consumer (`node .output/server/index.mjs`)
- With the fix, the same build returns 200 and renders DSD correctly
- Note: existing tests run under npm's flat node_modules, where the bug does not reproduce

Fixes #176
